### PR TITLE
Audit Git Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: 📦 Checkout repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: ⚙️ Setup node
         uses: actions/setup-node@v4
@@ -36,6 +38,8 @@ jobs:
     steps:
       - name: 📦 Checkout repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: ⚙️ Setup node
         uses: actions/setup-node@v4
@@ -55,6 +59,8 @@ jobs:
     steps:
       - name: 📦 Checkout repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: ⚙️ Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Use [zizmor](https://github.com/woodruffw/zizmor) to audit git actions and fix vulnerabilities.

* Prevents the checkout action from persisting git credentials [read more](https://woodruffw.github.io/zizmor/audits/#artipacked)